### PR TITLE
recipes-phosphor: patch: enable sol on Nuvoton's NPCM750.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Please see the corresponding sections below for details.
         * [Source URL](#source-url)
         * [How to use](#how-to-use)
         * [Maintainer](#maintainer)
+      * [SOL](#sol)
+        * [SOL URL](#sol-url)
+        * [SOL How to use](#sol-how-to-use)
+        * [SOL Maintainer](#sol-maintainer)
    * [Modifications](#modifications)
 <!--te-->
 
@@ -94,6 +98,30 @@ port 5900
 #### Maintainer
 Joseph Liu
 
+### SOL
+
+This is a patch for enabling SOL in [phosphor-webui](https://github.com/openbmc/phosphor-webui) on Nuvoton's NPCM750.
+
+The patch provides the [obmc-console](https://github.com/openbmc/obmc-console) configuration and an update to [phosphor-rest-server](https://github.com/openbmc/phosphor-rest-server).
+
+It's verified with Nuvoton's NPCM750 solution and Supermicro MBD-X9SCL-F-0.
+
+#### SOL URL
+
+https://github.com/NTC-CCBG/meta-openbmc-nuvoton-addon/tree/master/recipes-phosphor/console
+
+https://github.com/NTC-CCBG/meta-openbmc-nuvoton-addon/tree/master/recipes-phosphor/interfaces
+
+#### SOL How to use:
+
+1) Follow steps of the "Example Usage with OpenBMC" section in [phosphor-webui](https://github.com/openbmc/phosphor-webui#example-usage-with-openbmc).
+
+#### SOL Maintainer
+Tyrone Ting
+
+Stanley Chu
+
 ### Modifications
 
 * 2018.07.23 First release Remote-KVM
+* 2018.08.02 First release SOL

--- a/recipes-phosphor/console/files/obmc-console.conf
+++ b/recipes-phosphor/console/files/obmc-console.conf
@@ -1,0 +1,4 @@
+lpc-address = 0x3f8
+sirq = 4
+local-tty = ttyS1
+local-tty-baud = 115200

--- a/recipes-phosphor/console/obmc-console%.bbappend
+++ b/recipes-phosphor/console/obmc-console%.bbappend
@@ -1,0 +1,14 @@
+SUMMARY = "Nuvoton OpenBMC console daemon"
+DESCRIPTION = "Nuvoton Daemon to handle UART console connections"
+HOMEPAGE = "http://github.com/openbmc/obmc-console"
+PR = "r1"
+
+inherit obmc-phosphor-license
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+OBMC_CONSOLE_HOST_TTY := "ttyS1"
+
+do_build_append() {
+        install -m 0644 ${THISDIR}/files/${PN}.conf ${WORKDIR}/${PN}.conf
+}

--- a/recipes-phosphor/interfaces/phosphor-gevent%.bbappend
+++ b/recipes-phosphor/interfaces/phosphor-gevent%.bbappend
@@ -1,0 +1,4 @@
+SUMMARY = "Nuvoton Phosphor Rocket startup script"
+DESCRIPTION = "Nuvoton Phosphor Rocket startup script."
+
+SRCREV = "3a9a51c969c2aeb7cceb7b2bee203a10afb2da95"


### PR DESCRIPTION
SOL commit

1. It modifies obmc-console configuration file and updates the version of phosphor-rest-server.
2. It's verified with Supermicro MBD-X9SCL-F-0.